### PR TITLE
Fix table being abridged when too many rows

### DIFF
--- a/meteociel.py
+++ b/meteociel.py
@@ -156,4 +156,5 @@ if __name__ == '__main__':
         _plot_weather_data(data[['Time', 'Temperature', 'Wind Speed', 'Precipitation']])
     
     else:
-        print(data[['Date', 'Time', 'Temperature', 'Wind Speed', 'Wind Gust', 'Precipitation', 'Humidity']])
+        with pd.option_context('display.max_rows', None, 'display.max_columns', None):
+            print(data[['Date', 'Time', 'Temperature', 'Wind Speed', 'Wind Gust', 'Precipitation', 'Humidity']])


### PR DESCRIPTION
When the number of rows in the table is too large (e.g. 90) the table was being abridged. This is fixed here by modifying locally a couple of pandas options.